### PR TITLE
GUACAMOLE-225: Bump version numbers to 0.9.12-incubating where appropriate.

### DIFF
--- a/src/chapters/custom-auth.xml
+++ b/src/chapters/custom-auth.xml
@@ -58,7 +58,7 @@
     &lt;groupId>org.apache.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-auth-tutorial&lt;/artifactId>
     &lt;packaging>jar&lt;/packaging>
-    &lt;version>0.9.11-incubating&lt;/version>
+    &lt;version>0.9.12-incubating&lt;/version>
     &lt;name>guacamole-auth-tutorial&lt;/name>
 
     &lt;properties>
@@ -88,7 +88,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-ext&lt;/artifactId>
-            &lt;version>0.9.11-incubating&lt;/version>
+            &lt;version>0.9.12-incubating&lt;/version>
             &lt;scope>provided&lt;/scope>
         &lt;/dependency>
 
@@ -172,7 +172,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
             <title>The required <filename>guac-manifest.json</filename></title>
             <programlisting>{
 
-    "guacamoleVersion" : "0.9.11-incubating",
+    "guacamoleVersion" : "0.9.12-incubating",
 
     "name"      : "Tutorial Authentication Extension",
     "namespace" : "guac-auth-tutorial",
@@ -196,7 +196,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
             <screen><prompt>$</prompt> mvn package
 <computeroutput>[INFO] Scanning for projects...
 [INFO] ------------------------------------------------------------------------
-[INFO] Building guacamole-auth-tutorial 0.9.11-incubating
+[INFO] Building guacamole-auth-tutorial 0.9.12-incubating
 [INFO] ------------------------------------------------------------------------
 ...
 [INFO] ------------------------------------------------------------------------
@@ -210,7 +210,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
         </informalexample>
         <para>Assuming you see the "<computeroutput>BUILD SUCCESS</computeroutput>" message when you
             build the extension, there will be a new file,
-                <filename>target/guacamole-auth-tutorial-0.9.11-incubating.jar</filename>, which can be
+                <filename>target/guacamole-auth-tutorial-0.9.12-incubating.jar</filename>, which can be
             installed within Guacamole and tested. If you changed the name or version of the project
             in the <filename>pom.xml</filename> file, the name of this new <filename>.jar</filename>
             file will be different, but it can still be found within
@@ -472,7 +472,7 @@ public Map&lt;String, GuacamoleConfiguration>
             user running Tomcat.</para>
         <para>To install your extension, ensure that the required properties have been added to your
                 <filename>guacamole.properties</filename>, copy the
-                <filename>target/guacamole-auth-tutorial-0.9.11-incubating.jar</filename> file into
+                <filename>target/guacamole-auth-tutorial-0.9.12-incubating.jar</filename> file into
                 <filename>GUACAMOLE_HOME/extensions</filename> and restart Tomcat. Guacamole will
             automatically load your extension, logging an informative message that it has done
             so:</para>

--- a/src/chapters/duo-auth.xml
+++ b/src/chapters/duo-auth.xml
@@ -55,7 +55,7 @@
                 >http://guacamole.incubator.apache.org/releases/</link>.</para>
         <para>The Duo authentication extension is packaged as a <filename>.tar.gz</filename> file
             containing only the extension itself,
-                <filename>guacamole-auth-duo-0.9.11-incubating.jar</filename>, which must ultimately
+                <filename>guacamole-auth-duo-0.9.12-incubating.jar</filename>, which must ultimately
             be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-duo-auth">
@@ -69,7 +69,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-duo-0.9.11-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-duo-0.9.12-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/guacamole-ext.xml
+++ b/src/chapters/guacamole-ext.xml
@@ -174,7 +174,7 @@
                     <filename>guac-manifest.json</filename> will look something like this:</para>
             <informalexample>
                 <programlisting>{
-    "guacamoleVersion" : "0.9.11-incubating",
+    "guacamoleVersion" : "0.9.12-incubating",
     "name" : "My Extension",
     "namespace" : "my-extension"
 }</programlisting>
@@ -186,7 +186,7 @@
             <informalexample>
                 <programlisting>{
 
-    "guacamoleVersion" : "0.9.11-incubating",
+    "guacamoleVersion" : "0.9.12-incubating",
 
     "name"      : "My Extension",
     "namespace" : "my-extension",

--- a/src/chapters/header-auth.xml
+++ b/src/chapters/header-auth.xml
@@ -29,7 +29,7 @@
                 >http://guacamole.incubator.apache.org/releases/</link>.</para>
         <para>The HTTP header authentication extension is packaged as a <filename>.tar.gz</filename>
             file containing only the extension itself,
-                <filename>guacamole-auth-header-0.9.11-incubating.jar</filename>, which must
+                <filename>guacamole-auth-header-0.9.12-incubating.jar</filename>, which must
             ultimately be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-header-auth">
@@ -46,7 +46,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-header-0.9.11-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-header-0.9.12-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -551,8 +551,8 @@
                 of a <filename>.tar.gz</filename> archive which you can extract from the command
                 line:</para>
             <informalexample>
-                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.11-incubating.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-server-0.9.11-incubating/</userinput>
+                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.12-incubating.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-server-0.9.12-incubating/</userinput>
 <prompt>$</prompt></screen>
             </informalexample>
             <para>If you want the absolute latest code, and don't care that the code hasn't been as
@@ -604,7 +604,7 @@ checking whether build environment is sane... yes
 ...
 
 ------------------------------------------------
-guacamole-server version 0.9.11-incubating
+guacamole-server version 0.9.12-incubating
 ------------------------------------------------
 
    Library status:
@@ -780,8 +780,8 @@ make[1]: Leaving directory `/home/zhz/guacamole/incubator-guacamole-server'</com
                 <filename>.tar.gz</filename> archive which you can extract from the command
             line:</para>
         <informalexample>
-            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.11-incubating.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-client-0.9.11-incubating/</userinput>
+            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.12-incubating.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-client-0.9.12-incubating/</userinput>
 <prompt>$</prompt></screen>
         </informalexample>
         <para>As with <package>guacamole-server</package>, if you want the absolute latest code, and
@@ -875,7 +875,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
             application from the name of the <filename>.war</filename> file, you will likely want to
             rename this to simply <filename>guacamole.war</filename> while copying:</para>
         <informalexample>
-            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.11-incubating.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
+            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.12-incubating.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
 <prompt>#</prompt></screen>
         </informalexample>
         <para>Again, if you are using a different servlet container or if Tomcat is installed to a
@@ -893,7 +893,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
 Starting Tomcat... OK</computeroutput>
 <prompt>#</prompt> <userinput>/etc/init.d/guacd start</userinput>
 <computeroutput>Starting guacd: SUCCESS
-guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.11-incubating started</computeroutput>
+guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.12-incubating started</computeroutput>
 <prompt>#</prompt></screen>
         </informalexample>
         <important>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -61,10 +61,10 @@
                 <term><filename>mysql/</filename></term>
                 <listitem>
                     <para>Contains the MySQL/MariaDB authentication extension,
-                            <filename>guacamole-auth-jdbc-mysql-0.9.11-incubating.jar</filename>,
+                            <filename>guacamole-auth-jdbc-mysql-0.9.12-incubating.jar</filename>,
                         along with a <filename>schema/</filename> directory containing
                         MySQL-specific SQL scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-mysql-0.9.11-incubating.jar</filename>
+                            <filename>guacamole-auth-jdbc-mysql-0.9.12-incubating.jar</filename>
                         file will ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the MySQL JDBC
                         driver must be placed within <filename>GUACAMOLE_HOME/lib</filename>.</para>
@@ -81,10 +81,10 @@
                 <term><filename>postgresql/</filename></term>
                 <listitem>
                     <para>Contains the PostgreSQL authentication extension,
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.11-incubating.jar</filename>,
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.12-incubating.jar</filename>,
                         along with a <filename>schema/</filename> directory containing
                         PostgreSQL-specific SQL scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.11-incubating.jar</filename>
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.12-incubating.jar</filename>
                         file will ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the PostgreSQL
                         JDBC driver must be placed within
@@ -361,9 +361,9 @@ CREATE INDEX</computeroutput>
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.11-incubating.jar</filename>
+                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.12-incubating.jar</filename>
                     <emphasis>or</emphasis>
-                    <filename>guacamole-auth-jdbc-postgresql-0.9.11-incubating.jar</filename> within
+                    <filename>guacamole-auth-jdbc-postgresql-0.9.12-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>, depending on whether you are
                     using MySQL/MariaDB or PostgreSQL.</para>
             </step>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -83,7 +83,7 @@
             containing:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>guacamole-auth-ldap-0.9.11-incubating.jar</filename></term>
+                <term><filename>guacamole-auth-ldap-0.9.12-incubating.jar</filename></term>
                 <listitem>
                     <para>The Guacamole LDAP support extension itself, which must be placed in
                             <filename>GUACAMOLE_HOME/extensions</filename>.</para>
@@ -211,7 +211,7 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-ldap-0.9.11-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-ldap-0.9.12-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/noauth.xml
+++ b/src/chapters/noauth.xml
@@ -35,7 +35,7 @@
             packaged as a <filename>.tar.gz</filename> file containing:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>guacamole-auth-noauth-0.9.11-incubating.jar</filename></term>
+                <term><filename>guacamole-auth-noauth-0.9.12-incubating.jar</filename></term>
                 <listitem>
                     <para>The NoAuth extension itself, which must be placed in
                             <filename>GUACAMOLE_HOME/extensions</filename>.</para>
@@ -61,7 +61,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-noauth-0.9.11-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-noauth-0.9.12-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/yourown.xml
+++ b/src/chapters/yourown.xml
@@ -112,7 +112,7 @@
     &lt;groupId>org.apache.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-tutorial&lt;/artifactId>
     &lt;packaging>war&lt;/packaging>
-    &lt;version>0.9.10-incubating&lt;/version>
+    &lt;version>0.9.12-incubating&lt;/version>
     &lt;name>guacamole-tutorial&lt;/name>
 
     &lt;properties>
@@ -201,7 +201,7 @@
             </informalexample>
             <para>Assuming you see the "<computeroutput>BUILD SUCCESSFUL</computeroutput>" message
                 when you build the web application, there will be a new file,
-                    <filename>target/guacamole-tutorial-0.9.10-incubating.war</filename>, which
+                    <filename>target/guacamole-tutorial-0.9.12-incubating.war</filename>, which
                 can be deployed to your servlet container and tested. If you changed the name or
                 version of the project in the <filename>pom.xml</filename> file, the name of this new
                     <filename>.war</filename> file will be different, but it can still be found
@@ -312,7 +312,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common-js&lt;/artifactId>
-            &lt;version>0.9.10-incubating&lt;/version>
+            &lt;version>0.9.12-incubating&lt;/version>
             &lt;type>zip&lt;/type>
             &lt;scope>runtime&lt;/scope>
         &lt;/dependency>
@@ -331,7 +331,7 @@
                 web application should build successfully, and the Guacamole JavaScript API should
                 be accessible in the <filename>guacamole-common-js/</filename> subdirectory of your
                 web application after it is deployed. A quick check that you can access
-                    <uri>/guacamole-tutorial-0.9.10-incubating/guacamole-common-js/all.min.js</uri>
+                    <uri>/guacamole-tutorial-0.9.12-incubating/guacamole-common-js/all.min.js</uri>
                 is probably worth the effort.</para>
         </section>
         <section xml:id="simple-tunnel">
@@ -430,7 +430,7 @@ public class TutorialGuacamoleTunnelServlet
                 to the URL we wish to use when making HTTP requests to the servlet:
                     <uri>/tunnel</uri>. This URL is relative to the context root of the web
                 application. In the case of this web application, the final absolute URL will be
-                    <uri>/guacamole-tutorial-0.9.10-incubating/tunnel</uri>.</para>
+                    <uri>/guacamole-tutorial-0.9.12-incubating/tunnel</uri>.</para>
         </section>
         <section xml:id="simple-client">
             <title>Adding the client</title>

--- a/src/gug.xml
+++ b/src/gug.xml
@@ -3,7 +3,7 @@
     xmlns:xi="http://www.w3.org/2001/XInclude">
     <info>
         <title>Guacamole Manual</title>
-        <edition>0.9.11-incubating</edition>
+        <edition>0.9.12-incubating</edition>
         <legalnotice>
             <para>Licensed to the Apache Software Foundation (ASF) under one or more contributor
                 license agreements. See the <link xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -42,7 +42,7 @@
             application, etc.) to give a good starting point beyond simply looking at the Guacamole
             codebase.</para>
         <para>This particular edition of the <citetitle>Guacamole Manual</citetitle> covers
-            Guacamole version 0.9.11-incubating. New releases which create new features or break
+            Guacamole version 0.9.12-incubating. New releases which create new features or break
             compatibility will result in new editions of the user's guide, as will any necessary
             corrections. As the official documentation for the project, this book will always be
             freely available in its entirety online.</para>

--- a/tutorials/guacamole-auth-tutorial/pom.xml
+++ b/tutorials/guacamole-auth-tutorial/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-tutorial</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.11-incubating</version>
+    <version>0.9.12-incubating</version>
     <name>guacamole-auth-tutorial</name>
 
     <properties>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.11-incubating</version>
+            <version>0.9.12-incubating</version>
             <scope>provided</scope>
         </dependency>
 

--- a/tutorials/guacamole-auth-tutorial/src/main/resources/guac-manifest.json
+++ b/tutorials/guacamole-auth-tutorial/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.11-incubating",
+    "guacamoleVersion" : "0.9.12-incubating",
 
     "name"      : "Tutorial Authentication Extension",
     "namespace" : "guac-auth-tutorial",

--- a/tutorials/guacamole-tutorial/pom.xml
+++ b/tutorials/guacamole-tutorial/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-tutorial</artifactId>
     <packaging>war</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.12-incubating</version>
     <name>guacamole-tutorial</name>
 
     <properties>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.12-incubating</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
This change bumps all version numbers referenced within the manual, with the exception of guacamole-common which is unchanged.