### PR TITLE
GUACAMOLE-244: Configuration of Dereferencing Aliases

### DIFF
--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -391,7 +391,8 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                             as it searches the tree.  Possible values for this property are "never" (the default)
                             so that aliases will never be followed, "searching" to dereference during search operations
                             after the base object is located, "finding" to dereference in order to locate the
-                            search base, but not during the actual search, and "always" to always dereference aliases.
+                            search base, but not during the actual search, and "always" to always dereference
+                            aliases.</para>
                     </listitem>
                 </varlistentry>
             </variablelist>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -388,11 +388,10 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                     <term><property>ldap-dereference-aliases</property></term>
                     <listitem>
                         <para>Controls whether or not the LDAP connection follows (dereferences) aliases
-                            as it searches the tree.  There are four possible values: never (the default),
-                            finding, searching, and always.  Never means aliases will never be followed;
-                            searching means they will be dereferenced during search, but not when finding
-                            the start of the search; finding means only when finding the start of the search,
-                            but not during the search; always means they will always be followed.</para>
+                            as it searches the tree.  Poossible values for this property are "never" (the default)
+                            so that aliases will never be followed, "searching" to dereference during search operations
+                            after the base object is located, "finding" to dereference in order to locate the
+                            search base, but not during the actual search, and "always" to always dereference aliases.
                     </listitem>
                 </varlistentry>
             </variablelist>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -384,6 +384,17 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                                 have no effect on Guacamole configurations.</emphasis></para>
                     </listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term><property>ldap-dereference-aliases</property></term>
+                    <listitem>
+                        <para>Controls whether or not the LDAP connection follows (dereferences) aliases
+                            as it searches the tree.  There are four possible values: never (the default),
+                            finding, searching, and always.  Never means aliases will never be followed;
+                            searching means they will be dereferenced during search, but not when finding
+                            the start of the search; finding means only when finding the start of the search,
+                            but not during the search; always means they will always be followed.</para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
             <para>Again, even if the defaults are sufficient for the other properties, <emphasis>you
                     must still specify the <property>ldap-user-base-dn</property>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -388,7 +388,7 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                     <term><property>ldap-dereference-aliases</property></term>
                     <listitem>
                         <para>Controls whether or not the LDAP connection follows (dereferences) aliases
-                            as it searches the tree.  Poossible values for this property are "never" (the default)
+                            as it searches the tree.  Possible values for this property are "never" (the default)
                             so that aliases will never be followed, "searching" to dereference during search operations
                             after the base object is located, "finding" to dereference in order to locate the
                             search base, but not during the actual search, and "always" to always dereference aliases.


### PR DESCRIPTION
This adds documentation for the single parameter added to the client that allows for configuring when the LDAP connection follows (dereferences) aliases.