### PR TITLE
GUACAMOLE-203: Update SSH documentation to include keepalive interval

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -2587,6 +2587,24 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                         the default of 22 will be used.</para>
                                 </entry>
                             </row>
+                            <row>
+                                <entry><parameter>server-alive-interval</parameter></entry>
+                                <entry>
+                                    <para>
+                                        <indexterm>
+                                            <primary>SSH</primary>
+                                            <secondary>server-alive-interval</secondary>
+                                        </indexterm>
+                                        By default the SSH client does not send keepalive requests
+                                        to the server.  This parameter allows you to configure the
+                                        the interval (in seconds) at which the client connection
+                                        sends keepalive packets to the server.  The default is 0,
+                                        which disables sending the packets.  A value of 1 is
+                                        automatically increased to 2.  Negative values are set to
+                                        0, disabling sending keepalives.
+                                    </para>
+                                </entry>
+                            </row>
                         </tbody>
                     </tgroup>
                 </informaltable>
@@ -2760,14 +2778,14 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                     </tgroup>
                 </informaltable>
             </section>
-            <section xml:id="ssh-environment">
-                <title>SSH Environment Settings</title>
-                <para>The following parameters allow you to adjust the environment used by the
-                    Guacamole SSH client.  Currently only two parameters are supported, allowing
-                    you to adjust the command executed during login (the defualt is to launch the
-                    user's shell) and change whether or not the SSH client sends keepalive packets
-                    to the server to prevent idle sessions from being automatically disconnected.
-                </para>
+            <section xml:id="ssh-command">
+                <title>Running a command (instead of a shell)</title>
+                <para>By default, SSH sessions will start an interactive shell. The shell which will
+                    be used is determined by the SSH server, normally by reading the user's default
+                    shell previously set with <command>chsh</command> or within
+                        <filename>/etc/passwd</filename>. If you wish to override this and instead
+                    run a specific command, you can do so by specifying that command in the
+                    configuration of the Guacamole SSH connection.</para>
                 <informaltable frame="all">
                     <indexterm>
                         <primary>parameters</primary>
@@ -2792,24 +2810,6 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                         </indexterm>The command to execute over the SSH session, if
                                         any. This parameter is optional. If not specified, the SSH
                                         session will use the user's default shell.</para>
-                                </entry>
-                            </row>
-                            <row>
-                                <entry><parameter>server-alive-interval</parameter></entry>
-                                <entry>
-                                    <para>
-                                        <indexterm>
-                                            <primary>SSH</primary>
-                                            <secondary>server-alive-interval</secondary>
-                                        </indexterm>
-                                        By default the SSH client does not send keepalive requests
-                                        to the server.  This parameter allows you to configure the
-                                        the interval (in seconds) at which the client connection
-                                        sends keepalive packets to the server.  The default is 0,
-                                        which disables sending the packets.  A value of 1 is
-                                        automatically increased to 2.  Negative values are set to
-                                        0, disabling sending keepalives.
-                                    </para>
                                 </entry>
                             </row>
                         </tbody>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -2738,14 +2738,14 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                     </tgroup>
                 </informaltable>
             </section>
-            <section xml:id="ssh-command">
-                <title>Running a command (instead of a shell)</title>
-                <para>By default, SSH sessions will start an interactive shell. The shell which will
-                    be used is determined by the SSH server, normally by reading the user's default
-                    shell previously set with <command>chsh</command> or within
-                        <filename>/etc/passwd</filename>. If you wish to override this and instead
-                    run a specific command, you can do so by specifying that command in the
-                    configuration of the Guacamole SSH connection.</para>
+            <section xml:id="ssh-environment">
+                <title>SSH Environment Settings</title>
+                <para>The following parameters allow you to adjust the environment used by the
+                    Guacamole SSH client.  Currently only two parameters are supported, allowing
+                    you to adjust the command executed during login (the defualt is to launch the
+                    user's shell) and change whether or not the SSH client sends keepalive packets
+                    to the server to prevent idle sessions from being automatically disconnected.
+                </para>
                 <informaltable frame="all">
                     <indexterm>
                         <primary>parameters</primary>
@@ -2770,6 +2770,23 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                         </indexterm>The command to execute over the SSH session, if
                                         any. This parameter is optional. If not specified, the SSH
                                         session will use the user's default shell.</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><parameter>server-alive-interval</parameter></entry>
+                                <entry>
+                                    <para>
+                                        <indexterm>
+                                            <primary>SSH</primary>
+                                            <secondary>server-alive-interval</secondary>
+                                        </indexterm>
+                                        By default the SSH client does not send keepalive requests
+                                        to the server.  This parameter allows you to configure the
+                                        the interval (in seconds) at which the client connection
+                                        sends keepalive packets to the server.  The default is 0,
+                                        which disables sending the packets.  A value of 1 is
+                                        automatically increased to 2 by libssh2.
+                                    </para>
                                 </entry>
                             </row>
                         </tbody>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -830,11 +830,11 @@ guacd-port:     4822</programlisting>
                             <row>
                                 <entry><parameter>sftp-server-alive-interval</parameter></entry>
                                 <entry>
-                                    <para>The interval at which to send keepalive packets to the
-                                    SSH server for the SFTP connection.  This parameter is optional.
-                                    If omitted, the default of 0 will be used, disabling sending
-                                    keepalive packets.  A value of 1 will be rounded up to 2.
-                                    Negative values are changed to 0, disabling sending keepalives.
+                                    <para>The interval in seconds at which to send keepalive
+                                    packets to the SSH server for the SFTP connection.  This
+                                    parameter is optional.  If omitted, the default of 0 will be
+                                    used, disabling sending keepalive packets.  The minimum
+                                    value is 2.
                                     </para>
                                 </entry>
                             </row>
@@ -2325,11 +2325,11 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                             <row>
                                 <entry><parameter>sftp-server-alive-interval</parameter></entry>
                                 <entry>
-                                    <para>The interval at which to send keepalive packets to the
-                                    SSH server for the SFTP connection.  This parameter is optional.
-                                    If omitted, the default of 0 will be used, disabling sending
-                                    keepalive packets.  A value of 1 will be rounded up to 2.
-                                    Negative values are changed to 0, disabling sending keepalives.
+                                    <para>The interval in seconds at which to send keepalive 
+                                    packets to the SSH server for the SFTP connection.  This 
+                                    parameter is optional.  If omitted, the default of 0 will be 
+                                    used, disabling sending keepalive packets.  The minimum 
+                                    value is 2.
                                     </para>
                                 </entry>
                             </row>
@@ -2597,11 +2597,10 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                         </indexterm>
                                         By default the SSH client does not send keepalive requests
                                         to the server.  This parameter allows you to configure the
-                                        the interval (in seconds) at which the client connection
+                                        the interval in seconds at which the client connection
                                         sends keepalive packets to the server.  The default is 0,
-                                        which disables sending the packets.  A value of 1 is
-                                        automatically increased to 2.  Negative values are set to
-                                        0, disabling sending keepalives.
+                                        which disables sending the packets.  The minimum value
+                                        is 2.
                                     </para>
                                 </entry>
                             </row>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -827,6 +827,17 @@ guacd-port:     4822</programlisting>
                                         will be used.</para>
                                 </entry>
                             </row>
+                            <row>
+                                <entry><parameter>sftp-server-alive-interval</parameter></entry>
+                                <entry>
+                                    <para>The interval at which to send keepalive packets to the
+                                    SSH server for the SFTP connection.  This parameter is optional.
+                                    If omitted, the default of 0 will be used, disabling sending
+                                    keepalive packets.  A value of 1 will be rounded up to 2.
+                                    Negative values are changed to 0, disabling sending keepalives.
+                                    </para>
+                                </entry>
+                            </row>
                         </tbody>
                     </tgroup>
                 </informaltable>
@@ -2311,6 +2322,17 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                         will be used.</para>
                                 </entry>
                             </row>
+                            <row>
+                                <entry><parameter>sftp-server-alive-interval</parameter></entry>
+                                <entry>
+                                    <para>The interval at which to send keepalive packets to the
+                                    SSH server for the SFTP connection.  This parameter is optional.
+                                    If omitted, the default of 0 will be used, disabling sending
+                                    keepalive packets.  A value of 1 will be rounded up to 2.
+                                    Negative values are changed to 0, disabling sending keepalives.
+                                    </para>
+                                </entry>
+                            </row>
                         </tbody>
                     </tgroup>
                 </informaltable>
@@ -2785,7 +2807,8 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                         the interval (in seconds) at which the client connection
                                         sends keepalive packets to the server.  The default is 0,
                                         which disables sending the packets.  A value of 1 is
-                                        automatically increased to 2 by libssh2.
+                                        automatically increased to 2.  Negative values are set to
+                                        0, disabling sending keepalives.
                                     </para>
                                 </entry>
                             </row>


### PR DESCRIPTION
Adding the new server-alive-interval parameter to the documentation for SSH connections.