### PR TITLE
GUACAMOLE-314: Bump version to 0.9.13-incubating.

### DIFF
--- a/src/chapters/cas-auth.xml
+++ b/src/chapters/cas-auth.xml
@@ -23,7 +23,7 @@
                 >http://guacamole.incubator.apache.org/releases/</link>.</para>
         <para>The CAS authentication extension is packaged as a <filename>.tar.gz</filename>
             file containing only the extension itself,
-                <filename>guacamole-auth-cas-0.9.12-incubating.jar</filename>, which must
+                <filename>guacamole-auth-cas-0.9.13-incubating.jar</filename>, which must
             ultimately be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-cas-auth">
@@ -40,7 +40,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-cas-0.9.12-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-cas-0.9.13-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/custom-auth.xml
+++ b/src/chapters/custom-auth.xml
@@ -58,7 +58,7 @@
     &lt;groupId>org.apache.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-auth-tutorial&lt;/artifactId>
     &lt;packaging>jar&lt;/packaging>
-    &lt;version>0.9.12-incubating&lt;/version>
+    &lt;version>0.9.13-incubating&lt;/version>
     &lt;name>guacamole-auth-tutorial&lt;/name>
 
     &lt;properties>
@@ -88,7 +88,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-ext&lt;/artifactId>
-            &lt;version>0.9.12-incubating&lt;/version>
+            &lt;version>0.9.13-incubating&lt;/version>
             &lt;scope>provided&lt;/scope>
         &lt;/dependency>
 
@@ -172,7 +172,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
             <title>The required <filename>guac-manifest.json</filename></title>
             <programlisting>{
 
-    "guacamoleVersion" : "0.9.12-incubating",
+    "guacamoleVersion" : "0.9.13-incubating",
 
     "name"      : "Tutorial Authentication Extension",
     "namespace" : "guac-auth-tutorial",
@@ -196,7 +196,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
             <screen><prompt>$</prompt> mvn package
 <computeroutput>[INFO] Scanning for projects...
 [INFO] ------------------------------------------------------------------------
-[INFO] Building guacamole-auth-tutorial 0.9.12-incubating
+[INFO] Building guacamole-auth-tutorial 0.9.13-incubating
 [INFO] ------------------------------------------------------------------------
 ...
 [INFO] ------------------------------------------------------------------------
@@ -210,7 +210,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
         </informalexample>
         <para>Assuming you see the "<computeroutput>BUILD SUCCESS</computeroutput>" message when you
             build the extension, there will be a new file,
-                <filename>target/guacamole-auth-tutorial-0.9.12-incubating.jar</filename>, which can be
+                <filename>target/guacamole-auth-tutorial-0.9.13-incubating.jar</filename>, which can be
             installed within Guacamole and tested. If you changed the name or version of the project
             in the <filename>pom.xml</filename> file, the name of this new <filename>.jar</filename>
             file will be different, but it can still be found within
@@ -472,7 +472,7 @@ public Map&lt;String, GuacamoleConfiguration>
             user running Tomcat.</para>
         <para>To install your extension, ensure that the required properties have been added to your
                 <filename>guacamole.properties</filename>, copy the
-                <filename>target/guacamole-auth-tutorial-0.9.12-incubating.jar</filename> file into
+                <filename>target/guacamole-auth-tutorial-0.9.13-incubating.jar</filename> file into
                 <filename>GUACAMOLE_HOME/extensions</filename> and restart Tomcat. Guacamole will
             automatically load your extension, logging an informative message that it has done
             so:</para>

--- a/src/chapters/duo-auth.xml
+++ b/src/chapters/duo-auth.xml
@@ -55,7 +55,7 @@
                 >http://guacamole.incubator.apache.org/releases/</link>.</para>
         <para>The Duo authentication extension is packaged as a <filename>.tar.gz</filename> file
             containing only the extension itself,
-                <filename>guacamole-auth-duo-0.9.12-incubating.jar</filename>, which must ultimately
+                <filename>guacamole-auth-duo-0.9.13-incubating.jar</filename>, which must ultimately
             be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-duo-auth">
@@ -69,7 +69,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-duo-0.9.12-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-duo-0.9.13-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/guacamole-ext.xml
+++ b/src/chapters/guacamole-ext.xml
@@ -174,7 +174,7 @@
                     <filename>guac-manifest.json</filename> will look something like this:</para>
             <informalexample>
                 <programlisting>{
-    "guacamoleVersion" : "0.9.12-incubating",
+    "guacamoleVersion" : "0.9.13-incubating",
     "name" : "My Extension",
     "namespace" : "my-extension"
 }</programlisting>
@@ -186,7 +186,7 @@
             <informalexample>
                 <programlisting>{
 
-    "guacamoleVersion" : "0.9.12-incubating",
+    "guacamoleVersion" : "0.9.13-incubating",
 
     "name"      : "My Extension",
     "namespace" : "my-extension",

--- a/src/chapters/header-auth.xml
+++ b/src/chapters/header-auth.xml
@@ -29,7 +29,7 @@
                 >http://guacamole.incubator.apache.org/releases/</link>.</para>
         <para>The HTTP header authentication extension is packaged as a <filename>.tar.gz</filename>
             file containing only the extension itself,
-                <filename>guacamole-auth-header-0.9.12-incubating.jar</filename>, which must
+                <filename>guacamole-auth-header-0.9.13-incubating.jar</filename>, which must
             ultimately be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-header-auth">
@@ -46,7 +46,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-header-0.9.12-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-header-0.9.13-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -551,8 +551,8 @@
                 of a <filename>.tar.gz</filename> archive which you can extract from the command
                 line:</para>
             <informalexample>
-                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.12-incubating.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-server-0.9.12-incubating/</userinput>
+                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.13-incubating.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-server-0.9.13-incubating/</userinput>
 <prompt>$</prompt></screen>
             </informalexample>
             <para>If you want the absolute latest code, and don't care that the code hasn't been as
@@ -604,7 +604,7 @@ checking whether build environment is sane... yes
 ...
 
 ------------------------------------------------
-guacamole-server version 0.9.12-incubating
+guacamole-server version 0.9.13-incubating
 ------------------------------------------------
 
    Library status:
@@ -780,8 +780,8 @@ make[1]: Leaving directory `/home/zhz/guacamole/incubator-guacamole-server'</com
                 <filename>.tar.gz</filename> archive which you can extract from the command
             line:</para>
         <informalexample>
-            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.12-incubating.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-client-0.9.12-incubating/</userinput>
+            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.13-incubating.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-client-0.9.13-incubating/</userinput>
 <prompt>$</prompt></screen>
         </informalexample>
         <para>As with <package>guacamole-server</package>, if you want the absolute latest code, and
@@ -875,7 +875,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
             application from the name of the <filename>.war</filename> file, you will likely want to
             rename this to simply <filename>guacamole.war</filename> while copying:</para>
         <informalexample>
-            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.12-incubating.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
+            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.13-incubating.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
 <prompt>#</prompt></screen>
         </informalexample>
         <para>Again, if you are using a different servlet container or if Tomcat is installed to a
@@ -893,7 +893,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
 Starting Tomcat... OK</computeroutput>
 <prompt>#</prompt> <userinput>/etc/init.d/guacd start</userinput>
 <computeroutput>Starting guacd: SUCCESS
-guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.12-incubating started</computeroutput>
+guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.13-incubating started</computeroutput>
 <prompt>#</prompt></screen>
         </informalexample>
         <important>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -165,76 +165,41 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
             </informalexample>
             <para>If the operation is successful, all tables have been created successfully, and the
                 database is now ready for use.</para>
-            <important>
-                <para>If you are upgrading from an older version of Guacamole that lacked support
-                    for connection groups (older than 0.8.2), you should instead run the upgrade
-                    script located within the <filename>upgrade/</filename> directory:</para>
+            <important xml:id="jdbc-auth-mysql-upgrade">
+                <para>If you are upgrading from an older version of Guacamole and were already using
+                    MySQL, you may need to run one or more database schema upgrade scripts located
+                    within the <filename>schema/upgrade/</filename> directory. Each of these scripts
+                    is named <filename>upgrade-pre-<replaceable>VERSION</replaceable>.sql</filename>
+                    where <replaceable>VERSION</replaceable> is the version of Guacamole where those
+                    changes were introduced. They need to be run when you are upgrading from a
+                    version of Guacamole older than <replaceable>VERSION</replaceable>:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>ls schema/upgrade/</userinput>
 <computeroutput>upgrade-pre-0.8.2.sql   upgrade-pre-0.9.13.sql  upgrade-pre-0.9.8.sql
 upgrade-pre-0.9.10.sql  upgrade-pre-0.9.6.sql   upgrade-pre-0.9.9.sql
 upgrade-pre-0.9.11.sql  upgrade-pre-0.9.7.sql</computeroutput>
-<prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.8.2.sql</userinput>
-<prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
-<prompt>$</prompt></screen>
-                    <para>If you are upgrading from a version of Guacamole before 0.9.6, the default
-                        permissions associated with new users have changed such that users can
-                        change their own passwords. You may, if desired, run the upgrade script to
-                        migrate any existing users to the new permissions:</para>
-                </informalexample>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.6.sql</userinput>
-<prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
 <prompt>$</prompt></screen>
                 </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.7, schema changes
-                    regarding support for disabling users and expiring passwords need to be
-                    applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.7.sql</userinput>
-<prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.8, schema changes
-                    regarding support for restricting user access times and concurrent connection
-                    use need to be applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.8.sql</userinput>
-<prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.9, schema changes
-                    which add indexes improving the performance of connection history searches need
-                    to be applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.9.sql</userinput>
-<prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.10-incubating,
-                    schema changes which add support for screen sharing and session affinity
-                    need to be applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.10.sql</userinput>
-<prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.11-incubating,
-                    schema changes which add support for password policies need to be
-                    applied:</para>
+                <para>These scripts are incremental and, when relevant, <emphasis>must be run in
+                        order</emphasis>. For example, if you are upgrading an existing database
+                    from version 0.9.10-incubating, you would need to run the
+                        <filename>upgrade-pre-0.9.11.sql</filename> script (because 0.9.10 is older
+                    than 0.9.11), followed by the <filename>upgrade-pre-0.9.13.sql</filename> script
+                    (because 0.9.10 is also older than 0.9.13):</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.11.sql</userinput>
 <prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.13-incubating,
-                    schema changes which add support for per-connection guacd instances and user
-                    profiles need to be applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.13.sql</userinput>
+<prompt>$</prompt>
+<prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.13.sql</userinput>
 <prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
 <prompt>$</prompt></screen>
                 </informalexample>
+                <para>If there are no
+                        <filename>upgrade-pre-<replaceable>VERSION</replaceable>.sql</filename>
+                    scripts present in the <filename>schema/upgrade/</filename> directory which
+                    apply to your existing Guacamole database, then the schema has not changed
+                    between your version and the version your are installing, and there is no need
+                    to run any database upgrade scripts.</para>
             </important>
         </section>
         <section xml:id="jdbc-auth-postgresql">
@@ -273,92 +238,33 @@ Type "help" for help.
 <prompt>guacamole=# </prompt><userinput>\q</userinput>
 <prompt>$</prompt></screen>
             </informalexample>
-            <important>
-                <para>If you are upgrading from an older version of Guacamole that lacked support
-                    disabling users and expiring passwords (older than 0.9.7), you should instead
-                    run the upgrade script located within the <filename>upgrade/</filename>
-                    directory:</para>
+            <important xml:id="jdbc-auth-postgresql-upgrade">
+                <para>If you are upgrading from an older version of Guacamole and were already using
+                    PostgreSQL, you may need to run one or more database schema upgrade scripts
+                    located within the <filename>schema/upgrade/</filename> directory. Each of these
+                    scripts is named
+                        <filename>upgrade-pre-<replaceable>VERSION</replaceable>.sql</filename>
+                    where <replaceable>VERSION</replaceable> is the version of Guacamole where those
+                    changes were introduced. They need to be run when you are upgrading from a
+                    version of Guacamole older than <replaceable>VERSION</replaceable>:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>ls schema/upgrade/</userinput>
 <computeroutput>upgrade-pre-0.9.10.sql  upgrade-pre-0.9.13.sql  upgrade-pre-0.9.8.sql
 upgrade-pre-0.9.11.sql  upgrade-pre-0.9.7.sql   upgrade-pre-0.9.9.sql</computeroutput>
-<prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.7.sql</userinput>
-<computeroutput>ALTER TABLE
-ALTER TABLE</computeroutput>
 <prompt>$</prompt></screen>
                 </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.8, schema
-                    changes regarding support for restricting user access times and concurrent
-                    connection use need to be applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.8.sql</userinput>
-<computeroutput>ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE</computeroutput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.9, schema
-                    changes which add indexes improving the performance of connection history
-                    searches need to be applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.9.sql</userinput>
-<computeroutput>CREATE INDEX
-CREATE INDEX
-CREATE INDEX</computeroutput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before
-                    0.9.10-incubating, schema changes which add support for screen sharing
-                    and session affinity need to be applied:</para>
-                <informalexample>
-                    <screen><prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.10.sql</userinput>
-<computeroutput>ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-UPDATE 0
-UPDATE 0
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-ALTER TYPE
-CREATE TABLE
-CREATE INDEX
-CREATE TABLE
-CREATE INDEX
-CREATE TABLE
-CREATE INDEX
-CREATE INDEX
-ALTER TABLE
-ALTER TABLE
-ALTER TABLE
-CREATE INDEX</computeroutput>
-<prompt>$</prompt></screen>
-                </informalexample>
-                <para>If you are upgrading from a version of Guacamole before 0.9.11-incubating,
-                    schema changes which add support for password policies need to be
-                    applied:</para>
+                <para>These scripts are incremental and, when relevant, <emphasis>must be run in
+                        order</emphasis>. For example, if you are upgrading an existing database
+                    from version 0.9.10-incubating, you would need to run the
+                        <filename>upgrade-pre-0.9.11.sql</filename> script (because 0.9.10 is older
+                    than 0.9.11), followed by the <filename>upgrade-pre-0.9.13.sql</filename> script
+                    (because 0.9.10 is also older than 0.9.13):</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.11.sql</userinput>
 <computeroutput>ALTER TABLE
 CREATE TABLE
 CREATE INDEX</computeroutput>
-<prompt>$</prompt></screen>
-                    <para>If you are upgrading from a version of Guacamole before 0.9.13-incubating,
-                        schema changes which add support for per-connection guacd instances and user
-                        profiles need to be applied:</para>
-                    <informalexample>
-                        <screen><prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.13.sql</userinput>
+<prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.13.sql</userinput>
 <computeroutput>CREATE TYPE
 ALTER TABLE
 ALTER TABLE
@@ -368,8 +274,13 @@ ALTER TABLE
 ALTER TABLE
 ALTER TABLE</computeroutput>
 <prompt>$</prompt></screen>
-                    </informalexample>
                 </informalexample>
+                <para>If there are no
+                        <filename>upgrade-pre-<replaceable>VERSION</replaceable>.sql</filename>
+                    scripts present in the <filename>schema/upgrade/</filename> directory which
+                    apply to your existing Guacamole database, then the schema has not changed
+                    between your version and the version your are installing, and there is no need
+                    to run any database upgrade scripts.</para>
             </important>
         </section>
     </section>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -275,6 +275,22 @@ ALTER TABLE
 ALTER TABLE</computeroutput>
 <prompt>$</prompt></screen>
                 </informalexample>
+                <para>Because the permissions granted to the Guacamole-specific PostgreSQL user when
+                    the database was first created will not automatically be granted for any new
+                    tables and sequences, you will also need to re-grant those permissions after
+                    applying any upgrade relevant scripts:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable></userinput>
+<computeroutput>psql (9.3.6)
+Type "help" for help.
+</computeroutput>
+<prompt>guacamole=# </prompt><userinput>GRANT SELECT,INSERT,UPDATE,DELETE ON ALL TABLES IN SCHEMA public TO <replaceable>guacamole_user</replaceable>;</userinput>
+<computeroutput>GRANT</computeroutput>
+<prompt>guacamole=# </prompt><userinput>GRANT SELECT,USAGE ON ALL SEQUENCES IN SCHEMA public TO <replaceable>guacamole_user</replaceable>;</userinput>
+<computeroutput>GRANT</computeroutput>
+<prompt>guacamole=# </prompt><userinput>\q</userinput>
+<prompt>$</prompt></screen>
+                </informalexample>
                 <para>If there are no
                         <filename>upgrade-pre-<replaceable>VERSION</replaceable>.sql</filename>
                     scripts present in the <filename>schema/upgrade/</filename> directory which

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -61,10 +61,10 @@
                 <term><filename>mysql/</filename></term>
                 <listitem>
                     <para>Contains the MySQL/MariaDB authentication extension,
-                            <filename>guacamole-auth-jdbc-mysql-0.9.12-incubating.jar</filename>,
+                            <filename>guacamole-auth-jdbc-mysql-0.9.13-incubating.jar</filename>,
                         along with a <filename>schema/</filename> directory containing
                         MySQL-specific SQL scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-mysql-0.9.12-incubating.jar</filename>
+                            <filename>guacamole-auth-jdbc-mysql-0.9.13-incubating.jar</filename>
                         file will ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the MySQL JDBC
                         driver must be placed within <filename>GUACAMOLE_HOME/lib</filename>.</para>
@@ -81,10 +81,10 @@
                 <term><filename>postgresql/</filename></term>
                 <listitem>
                     <para>Contains the PostgreSQL authentication extension,
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.12-incubating.jar</filename>,
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.13-incubating.jar</filename>,
                         along with a <filename>schema/</filename> directory containing
                         PostgreSQL-specific SQL scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.12-incubating.jar</filename>
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.13-incubating.jar</filename>
                         file will ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the PostgreSQL
                         JDBC driver must be placed within
@@ -361,9 +361,9 @@ CREATE INDEX</computeroutput>
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.12-incubating.jar</filename>
+                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.13-incubating.jar</filename>
                     <emphasis>or</emphasis>
-                    <filename>guacamole-auth-jdbc-postgresql-0.9.12-incubating.jar</filename> within
+                    <filename>guacamole-auth-jdbc-postgresql-0.9.13-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>, depending on whether you are
                     using MySQL/MariaDB or PostgreSQL.</para>
             </step>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -171,9 +171,9 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
                     script located within the <filename>upgrade/</filename> directory:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>ls schema/upgrade/</userinput>
-<computeroutput>upgrade-pre-0.8.2.sql   upgrade-pre-0.9.6.sql  upgrade-pre-0.9.9.sql
-upgrade-pre-0.9.10.sql  upgrade-pre-0.9.7.sql
-upgrade-pre-0.9.11.sql  upgrade-pre-0.9.8.sq</computeroutput>
+<computeroutput>upgrade-pre-0.8.2.sql   upgrade-pre-0.9.13.sql  upgrade-pre-0.9.8.sql
+upgrade-pre-0.9.10.sql  upgrade-pre-0.9.6.sql   upgrade-pre-0.9.9.sql
+upgrade-pre-0.9.11.sql  upgrade-pre-0.9.7.sql</computeroutput>
 <prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.8.2.sql</userinput>
 <prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
 <prompt>$</prompt></screen>
@@ -227,6 +227,14 @@ upgrade-pre-0.9.11.sql  upgrade-pre-0.9.8.sq</computeroutput>
 <prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
 <prompt>$</prompt></screen>
                 </informalexample>
+                <para>If you are upgrading from a version of Guacamole before 0.9.13-incubating,
+                    schema changes which add support for per-connection guacd instances and user
+                    profiles need to be applied:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <userinput>mysql -u root -p <replaceable>guacamole_db</replaceable> &lt; schema/upgrade/upgrade-pre-0.9.13.sql</userinput>
+<prompt>Enter password:</prompt> <userinput><replaceable>password</replaceable></userinput>
+<prompt>$</prompt></screen>
+                </informalexample>
             </important>
         </section>
         <section xml:id="jdbc-auth-postgresql">
@@ -272,8 +280,8 @@ Type "help" for help.
                     directory:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>ls schema/upgrade/</userinput>
-<computeroutput>upgrade-pre-0.9.10.sql  upgrade-pre-0.9.7.sql  upgrade-pre-0.9.9.sql
-upgrade-pre-0.9.11.sql  upgrade-pre-0.9.8.sql</computeroutput>
+<computeroutput>upgrade-pre-0.9.10.sql  upgrade-pre-0.9.13.sql  upgrade-pre-0.9.8.sql
+upgrade-pre-0.9.11.sql  upgrade-pre-0.9.7.sql   upgrade-pre-0.9.9.sql</computeroutput>
 <prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.7.sql</userinput>
 <computeroutput>ALTER TABLE
 ALTER TABLE</computeroutput>
@@ -346,6 +354,21 @@ CREATE INDEX</computeroutput>
 CREATE TABLE
 CREATE INDEX</computeroutput>
 <prompt>$</prompt></screen>
+                    <para>If you are upgrading from a version of Guacamole before 0.9.13-incubating,
+                        schema changes which add support for per-connection guacd instances and user
+                        profiles need to be applied:</para>
+                    <informalexample>
+                        <screen><prompt>$</prompt> <userinput>psql -d <replaceable>guacamole_db</replaceable> -f schema/upgrade/upgrade-pre-0.9.13.sql</userinput>
+<computeroutput>CREATE TYPE
+ALTER TABLE
+ALTER TABLE
+ALTER TABLE
+ALTER TABLE
+ALTER TABLE
+ALTER TABLE
+ALTER TABLE</computeroutput>
+<prompt>$</prompt></screen>
+                    </informalexample>
                 </informalexample>
             </important>
         </section>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -83,7 +83,7 @@
             containing:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>guacamole-auth-ldap-0.9.12-incubating.jar</filename></term>
+                <term><filename>guacamole-auth-ldap-0.9.13-incubating.jar</filename></term>
                 <listitem>
                     <para>The Guacamole LDAP support extension itself, which must be placed in
                             <filename>GUACAMOLE_HOME/extensions</filename>.</para>
@@ -211,7 +211,7 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-ldap-0.9.12-incubating.jar</filename> within
+                <para>Copy <filename>guacamole-auth-ldap-0.9.13-incubating.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/yourown.xml
+++ b/src/chapters/yourown.xml
@@ -112,7 +112,7 @@
     &lt;groupId>org.apache.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-tutorial&lt;/artifactId>
     &lt;packaging>war&lt;/packaging>
-    &lt;version>0.9.12-incubating&lt;/version>
+    &lt;version>0.9.13-incubating&lt;/version>
     &lt;name>guacamole-tutorial&lt;/name>
 
     &lt;properties>
@@ -201,7 +201,7 @@
             </informalexample>
             <para>Assuming you see the "<computeroutput>BUILD SUCCESSFUL</computeroutput>" message
                 when you build the web application, there will be a new file,
-                    <filename>target/guacamole-tutorial-0.9.12-incubating.war</filename>, which
+                    <filename>target/guacamole-tutorial-0.9.13-incubating.war</filename>, which
                 can be deployed to your servlet container and tested. If you changed the name or
                 version of the project in the <filename>pom.xml</filename> file, the name of this new
                     <filename>.war</filename> file will be different, but it can still be found
@@ -304,7 +304,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common&lt;/artifactId>
-            &lt;version>0.9.10-incubating&lt;/version>
+            &lt;version>0.9.13-incubating&lt;/version>
             &lt;scope>compile&lt;/scope>
         &lt;/dependency>
 
@@ -312,7 +312,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common-js&lt;/artifactId>
-            &lt;version>0.9.12-incubating&lt;/version>
+            &lt;version>0.9.13-incubating&lt;/version>
             &lt;type>zip&lt;/type>
             &lt;scope>runtime&lt;/scope>
         &lt;/dependency>
@@ -331,7 +331,7 @@
                 web application should build successfully, and the Guacamole JavaScript API should
                 be accessible in the <filename>guacamole-common-js/</filename> subdirectory of your
                 web application after it is deployed. A quick check that you can access
-                    <uri>/guacamole-tutorial-0.9.12-incubating/guacamole-common-js/all.min.js</uri>
+                    <uri>/guacamole-tutorial-0.9.13-incubating/guacamole-common-js/all.min.js</uri>
                 is probably worth the effort.</para>
         </section>
         <section xml:id="simple-tunnel">
@@ -430,7 +430,7 @@ public class TutorialGuacamoleTunnelServlet
                 to the URL we wish to use when making HTTP requests to the servlet:
                     <uri>/tunnel</uri>. This URL is relative to the context root of the web
                 application. In the case of this web application, the final absolute URL will be
-                    <uri>/guacamole-tutorial-0.9.12-incubating/tunnel</uri>.</para>
+                    <uri>/guacamole-tutorial-0.9.13-incubating/tunnel</uri>.</para>
         </section>
         <section xml:id="simple-client">
             <title>Adding the client</title>

--- a/src/gug.xml
+++ b/src/gug.xml
@@ -3,7 +3,7 @@
     xmlns:xi="http://www.w3.org/2001/XInclude">
     <info>
         <title>Guacamole Manual</title>
-        <edition>0.9.12-incubating</edition>
+        <edition>0.9.13-incubating</edition>
         <legalnotice>
             <para>Licensed to the Apache Software Foundation (ASF) under one or more contributor
                 license agreements. See the <link xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -42,7 +42,7 @@
             application, etc.) to give a good starting point beyond simply looking at the Guacamole
             codebase.</para>
         <para>This particular edition of the <citetitle>Guacamole Manual</citetitle> covers
-            Guacamole version 0.9.12-incubating. New releases which create new features or break
+            Guacamole version 0.9.13-incubating. New releases which create new features or break
             compatibility will result in new editions of the user's guide, as will any necessary
             corrections. As the official documentation for the project, this book will always be
             freely available in its entirety online.</para>

--- a/tutorials/guacamole-auth-tutorial/pom.xml
+++ b/tutorials/guacamole-auth-tutorial/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-tutorial</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.12-incubating</version>
+    <version>0.9.13-incubating</version>
     <name>guacamole-auth-tutorial</name>
 
     <properties>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.12-incubating</version>
+            <version>0.9.13-incubating</version>
             <scope>provided</scope>
         </dependency>
 

--- a/tutorials/guacamole-tutorial/pom.xml
+++ b/tutorials/guacamole-tutorial/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-tutorial</artifactId>
     <packaging>war</packaging>
-    <version>0.9.12-incubating</version>
+    <version>0.9.13-incubating</version>
     <name>guacamole-tutorial</name>
 
     <properties>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.13-incubating</version>
             <scope>compile</scope>
         </dependency>
 
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.12-incubating</version>
+            <version>0.9.13-incubating</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
As the database auth documentation was expanding badly with each change to the schema (one new paragraph per version), I've also generalized the documentation for the update scripts, hopefully simplifying things.