### PR TITLE
GUACAMOLE-328: OpenSSL Required for SSH Support

### DIFF
--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -240,8 +240,8 @@
                             non-release version from git</link>).</para>
                 </listitem>
                 <listitem>
-                    <para>SSH support depends on <package>libssh2</package> and
-                            <package>Pango</package> (a font rendering and text layout library, used
+                    <para>SSH support depends on <package>libssh2</package>, <package>OpenSSL</package>
+                        and <package>Pango</package> (a font rendering and text layout library, used
                         by Guacamole's built-in terminal emulator).</para>
                 </listitem>
                 <listitem>


### PR DESCRIPTION
Adds a little bit of clarifying language to the documentation to note that OpenSSL is required for SSH support.  This is already present in one section in the manual, but this adds to the section specific to building SSH support.