### PR TITLE
GUACAMOLE-357: Update Documentation for Ubuntu Specific Library

### DIFF
--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -136,8 +136,12 @@
                                         <colspec colname="c2" colnum="2" colwidth="1.0*"/>
                                         <tbody>
                                             <row>
-                                                <entry>Debian / Ubuntu package</entry>
+                                                <entry>Debian package</entry>
                                                 <entry><package>libjpeg62-turbo-dev</package></entry>
+                                            </row>
+                                            <row>
+                                                <entry>Ubuntu package</entry>
+                                                <entry><package>libjpeg-turbo8-dev</package></entry>
                                             </row>
                                             <row>
                                                 <entry>Fedora / CentOS / RHEL package</entry>


### PR DESCRIPTION
On Ubuntu the libjpeg62-turbo-dev package is named libjpeg-turbo8-dev, the instructions don't make that clear, I'd like to update the documentation to reflect that distinction.