### PR TITLE
GUACAMOLE-427: Fix documentation on load-balance-info parameter.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -2220,7 +2220,7 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                         </thead>
                         <tbody>
                             <row>
-                                <entry><parameter>load-balancing-info</parameter></entry>
+                                <entry><parameter>load-balance-info</parameter></entry>
                                 <entry>
                                     <para><indexterm>
                                             <primary>loadbalanceinfo</primary>


### PR DESCRIPTION
Quick fix.  Going to suggest this makes it into 0.9.14-incubating release.